### PR TITLE
[AP-29] filter by budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ## Getting Started
 
+* Copy `package.example.json` to `package.json`.
 * Press `F5` to open a new window with your extension loaded.
 * Run your command from the command palette by pressing (`Ctrl+Shift+P` or `Cmd+Shift+P` on Mac) and typing `Hello World`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -996,9 +996,9 @@
       }
     },
     "dotenv": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.0.tgz",
-      "integrity": "sha512-yy3x9XjojW8ROTBePD25AcMoHqGHsvHmtfw8QWlpEXyMMXXPj6brUA464AptUvHuTPRmNz6Sd3ZLNLeJl6dHJA=="
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
+      "integrity": "sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg=="
     },
     "electron-to-chromium": {
       "version": "1.3.644",

--- a/src/commands/HotpepperSearch.ts
+++ b/src/commands/HotpepperSearch.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode';
 import { HotpepperApi } from '../lib/api/HotpepperApi';
 import { HotpepperApiForm, HotpepperApiFormImpl } from '../lib/api/HotpepperApiForm';
-import { GeneralConfigImpl, GeneralConfig } from '../lib';
 import { HotpepperShopResponseListImpl } from "../lib/model/HotpepperShopResponseList";
 
 export function searchHotpepper(c: vscode.ExtensionContext): { dispose: any } {
@@ -9,25 +8,7 @@ export function searchHotpepper(c: vscode.ExtensionContext): { dispose: any } {
   const hotpepperApi: HotpepperApi = new HotpepperApi();
 
   return vscode.commands.registerCommand('appetizer.searchHotpepper', async () => {
-    // config
-    const generalConfigImpl: GeneralConfigImpl = new GeneralConfigImpl();
-    const generalConf: GeneralConfig = generalConfigImpl.getGeneralConf();
-
-    // parameter 作成
-    const priceRange = generalConf.priceRange?.sort();
-    const priceMin = priceRange === undefined ? 0 : priceRange[0];
-    const priceMax = priceRange === undefined ? priceMin : priceRange[1];
-    let lat = generalConf.latLng.lat;
-    let lng = generalConf.latLng.lng;
-    if (lat === undefined || lat === null) {
-      vscode.window.showInformationMessage('please set lat');
-      return;
-    }
-    if (lng === undefined || lng === null) {
-      vscode.window.showInformationMessage('please set lng');
-      return;
-    }
-    const hotpepperApiFormImpl = HotpepperApiFormImpl.newFromConfig(priceMin, priceMax, lat, lng);
+    const hotpepperApiFormImpl = HotpepperApiFormImpl.newFromConfig();
 
     // API call
     const hotpepperApiParamsList = hotpepperApiFormImpl.toApi();

--- a/src/commands/HotpepperSearch.ts
+++ b/src/commands/HotpepperSearch.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
 import { HotpepperApi } from '../lib/api/HotpepperApi';
-import { HotpepperApiForm } from '../lib/api/HotpepperApiForm';
+import { HotpepperApiForm, HotpepperApiFormImpl } from '../lib/api/HotpepperApiForm';
 import { GeneralConfigImpl, GeneralConfig } from '../lib';
+import { prependListener } from 'process';
 
 export function searchHotpepper(c: vscode.ExtensionContext): { dispose: any } {
   // api
@@ -13,21 +14,19 @@ export function searchHotpepper(c: vscode.ExtensionContext): { dispose: any } {
     const generalConf: GeneralConfig = generalConfigImpl.getGeneralConf();
 
     // parameter 作成
-    const params: HotpepperApiForm = {
-      // lat: generalConf.latLng.lat,
-      // lng: generalConf.latLng.lng,
-      lat: 35.6198513,
-      lng: 139.7281892,
-    };
-    console.log(params);
+    let hotpepperApiFormImpl = HotpepperApiFormImpl.newFromConfig(1200, 2500, 35.6198513, 139.7281892)
 
     // API call
-    const responseData = await hotpepperApi.searchShops(params);
+    let responseData = Promise.all(hotpepperApiFormImpl.getApiForm().map(param => hotpepperApi.searchShops(param)));
 
     if (responseData !== null) {
       // TODO: Hotpepper APIを採用していく場合は型を用意してレスポンスを解析する
-      console.log(responseData);
-      vscode.window.showInformationMessage(responseData.toString());
+      responseData.then(responses => {
+        let nestedResponses: Array<any> = Array.from(responses);
+        let flattenedResponses = [].concat.apply([],nestedResponses);
+        console.log(flattenedResponses);
+        vscode.window.showInformationMessage(flattenedResponses.toString());
+      })
     } else {
       vscode.window.showInformationMessage('API error');
     }

--- a/src/commands/HotpepperSearch.ts
+++ b/src/commands/HotpepperSearch.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode';
 import { HotpepperApi } from '../lib/api/HotpepperApi';
 import { HotpepperApiForm, HotpepperApiFormImpl } from '../lib/api/HotpepperApiForm';
 import { GeneralConfigImpl, GeneralConfig } from '../lib';
-import { prependListener } from 'process';
 import { HotpepperShopResponseListImpl } from "../lib/model/HotpepperShopResponseList";
 
 export function searchHotpepper(c: vscode.ExtensionContext): { dispose: any } {

--- a/src/commands/HotpepperSearch.ts
+++ b/src/commands/HotpepperSearch.ts
@@ -16,7 +16,7 @@ export function searchHotpepper(c: vscode.ExtensionContext): { dispose: any } {
     // parameter 作成
     const priceRange = generalConf.priceRange?.sort();
     const priceMin = priceRange === undefined ? 0 : priceRange[0];
-    const priceMax = priceRange === undefined ? 0 : priceRange[1];
+    const priceMax = priceRange === undefined ? priceMin : priceRange[1];
     let lat = generalConf.latLng.lat;
     let lng = generalConf.latLng.lng;
     if (lat === undefined || lat === null) {

--- a/src/commands/HotpepperSearch.ts
+++ b/src/commands/HotpepperSearch.ts
@@ -30,7 +30,7 @@ export function searchHotpepper(c: vscode.ExtensionContext): { dispose: any } {
     let hotpepperApiFormImpl = HotpepperApiFormImpl.newFromConfig(priceMin, priceMax, lat, lng);
 
     // API call
-    let responseData = await hotpepperApi.searchShops(hotpepperApiFormImpl.getApiForm());
+    let responseData = await hotpepperApi.searchShops(hotpepperApiFormImpl.toApi());
 
     if (responseData !== null) {
       vscode.window.showInformationMessage('get shops');

--- a/src/commands/HotpepperSearch.ts
+++ b/src/commands/HotpepperSearch.ts
@@ -30,16 +30,11 @@ export function searchHotpepper(c: vscode.ExtensionContext): { dispose: any } {
     let hotpepperApiFormImpl = HotpepperApiFormImpl.newFromConfig(priceMin, priceMax, lat, lng);
 
     // API call
-    let responseData = Promise.all(hotpepperApiFormImpl.getApiForm().map(param => hotpepperApi.searchShops(param)));
+    let responseData = await hotpepperApi.searchShops(hotpepperApiFormImpl.getApiForm());
 
     if (responseData !== null) {
-      // TODO: Hotpepper APIを採用していく場合は型を用意してレスポンスを解析する
-      responseData.then(responses => {
-        let nestedResponses: Array<any> = Array.from(responses);
-        let flattenedResponses = [].concat.apply([],nestedResponses);
-        console.log(flattenedResponses);
-        vscode.window.showInformationMessage(flattenedResponses.toString());
-      })
+      vscode.window.showInformationMessage('get shops');
+      console.log(responseData);
     } else {
       vscode.window.showInformationMessage('API error');
     }

--- a/src/commands/HotpepperSearch.ts
+++ b/src/commands/HotpepperSearch.ts
@@ -14,7 +14,20 @@ export function searchHotpepper(c: vscode.ExtensionContext): { dispose: any } {
     const generalConf: GeneralConfig = generalConfigImpl.getGeneralConf();
 
     // parameter 作成
-    let hotpepperApiFormImpl = HotpepperApiFormImpl.newFromConfig(1200, 2500, 35.6198513, 139.7281892)
+    const priceRange = generalConf.priceRange?.sort();
+    const priceMin = priceRange === undefined ? 0 : priceRange[0];
+    const priceMax = priceRange === undefined ? 0 : priceRange[1];
+    let lat = generalConf.latLng.lat;
+    let lng = generalConf.latLng.lng;
+    if (lat === undefined || lat === null) {
+      vscode.window.showInformationMessage('please set lat');
+      return;
+    }
+    if (lng === undefined || lng === null) {
+      vscode.window.showInformationMessage('please set lng');
+      return;
+    }
+    let hotpepperApiFormImpl = HotpepperApiFormImpl.newFromConfig(priceMin, priceMax, lat, lng);
 
     // API call
     let responseData = Promise.all(hotpepperApiFormImpl.getApiForm().map(param => hotpepperApi.searchShops(param)));

--- a/src/commands/ShowAppetizer.ts
+++ b/src/commands/ShowAppetizer.ts
@@ -21,6 +21,7 @@ export function showAppetizer(c: vscode.ExtensionContext): { dispose: any } {
   appetizerView.buildHtml();
 
   const params: HotpepperApiForm = {
+    budget: "B001",
     lat: 35.6198513,
     lng: 139.7281892,
   };

--- a/src/commands/ShowAppetizer.ts
+++ b/src/commands/ShowAppetizer.ts
@@ -24,6 +24,7 @@ export function showAppetizer(c: vscode.ExtensionContext): { dispose: any } {
     budget: "B001",
     lat: 35.6198513,
     lng: 139.7281892,
+    count: 30,
   };
 
   // API

--- a/src/lib/api/HotpepperApi.ts
+++ b/src/lib/api/HotpepperApi.ts
@@ -28,12 +28,16 @@ export class HotpepperApi {
         },
       });
 
+<<<<<<< HEAD
       if (response.data === null) {
         return null;
       }
 
       // create response model
       return HotpepperShopImpl.newFromApiResponse(response.data);
+=======
+      return response.data.results.shop;
+>>>>>>> 7222837 (Filter by budget)
     } catch (error) {
       console.log(error);
       return null;

--- a/src/lib/api/HotpepperApi.ts
+++ b/src/lib/api/HotpepperApi.ts
@@ -15,7 +15,7 @@ export class HotpepperApi {
     this.apiKey = apiKeyImpl.getHotpepperApiKey() as string;
   }
 
-  private async searchShop(hotpepperApiParams: HotpepperApiForm): Promise<Object | null> {
+  public async searchShop(hotpepperApiParams: HotpepperApiForm): Promise<Object | null> {
     // execute api
     try {
       const response = await axios.get(this.HOTPEPPER_API_ENDPOINT, {
@@ -27,29 +27,6 @@ export class HotpepperApi {
       });
 
       return response.data.results.shop;
-    } catch (error) {
-      console.log(error);
-      return null;
-    }
-  }
-
-  async searchShops(hotpepperApiParamsList: Array<HotpepperApiForm>): Promise<Object | null> {
-    // execute api
-    try {
-      let responseData = Promise.all(hotpepperApiParamsList.map(param => this.searchShop(param)));
-
-        // TODO: Hotpepper APIを採用していく場合は型を用意してレスポンスを解析する
-      let selectedShops = responseData.then(responses => {
-          let nestedResponses: Array<any> = Array.from(responses);
-          let flattenedResponses = [].concat.apply([],nestedResponses);
-          console.log('Num of all response data:', flattenedResponses.length);
-          const selectedNum = 4;
-          const selectedResponses = [...Array(selectedNum)].map(() =>
-            flattenedResponses.splice(Math.floor(Math.random() * flattenedResponses.length), 1)[0]);
-          console.log('Num of selected data:', selectedResponses.length);
-          return selectedResponses;
-        });
-      return selectedShops;
     } catch (error) {
       console.log(error);
       return null;

--- a/src/lib/api/HotpepperApi.ts
+++ b/src/lib/api/HotpepperApi.ts
@@ -15,9 +15,7 @@ export class HotpepperApi {
     this.apiKey = apiKeyImpl.getHotpepperApiKey() as string;
   }
 
-  async searchShops(
-    hotpepperApiParams: HotpepperApiForm
-  ): Promise<HotpepperShopImpl | null> {
+  private async searchShop(hotpepperApiParams: HotpepperApiForm): Promise<Object | null> {
     // execute api
     try {
       const response = await axios.get(this.HOTPEPPER_API_ENDPOINT, {
@@ -28,16 +26,30 @@ export class HotpepperApi {
         },
       });
 
-<<<<<<< HEAD
-      if (response.data === null) {
-        return null;
-      }
-
-      // create response model
-      return HotpepperShopImpl.newFromApiResponse(response.data);
-=======
       return response.data.results.shop;
->>>>>>> 7222837 (Filter by budget)
+    } catch (error) {
+      console.log(error);
+      return null;
+    }
+  }
+
+  async searchShops(hotpepperApiParamsList: Array<HotpepperApiForm>): Promise<Object | null> {
+    // execute api
+    try {
+      let responseData = Promise.all(hotpepperApiParamsList.map(param => this.searchShop(param)));
+
+        // TODO: Hotpepper APIを採用していく場合は型を用意してレスポンスを解析する
+      let selectedShops = responseData.then(responses => {
+          let nestedResponses: Array<any> = Array.from(responses);
+          let flattenedResponses = [].concat.apply([],nestedResponses);
+          console.log('Num of all response data:', flattenedResponses.length);
+          const selectedNum = 4;
+          const selectedResponses = [...Array(selectedNum)].map(() =>
+            flattenedResponses.splice(Math.floor(Math.random() * flattenedResponses.length), 1)[0]);
+          console.log('Num of selected data:', selectedResponses.length);
+          return selectedResponses;
+        });
+      return selectedShops;
     } catch (error) {
       console.log(error);
       return null;

--- a/src/lib/api/HotpepperApiForm.ts
+++ b/src/lib/api/HotpepperApiForm.ts
@@ -1,4 +1,5 @@
 import { BudgetList } from "../../lib/model/HotpepperBudgetModel";
+import { GeneralConfigImpl, GeneralConfig } from '../../lib';
 
 /**
  * Hot Pepper API検索用のパラメーター
@@ -14,19 +15,24 @@ export class HotpepperApiFormImpl {
   private apiForm: Array<HotpepperApiForm>;
   private budgetMin: number = 0;
   private budgetMax: number = 0;
-  private lat: number = 0;
-  private lng: number = 0;
+  private lat: number | null | undefined = 0;
+  private lng: number | null | undefined = 0;
 
   constructor() {
     this.apiForm = [];
   }
 
-  public static newFromConfig(budgetMin: number, budgetMax: number, lat: number, lng: number): HotpepperApiFormImpl {
+  public static newFromConfig(): HotpepperApiFormImpl {
     const hotpepperApiFormImpl: HotpepperApiFormImpl = new HotpepperApiFormImpl();
-    hotpepperApiFormImpl.budgetMin = budgetMin;
-    hotpepperApiFormImpl.budgetMax = budgetMax;
-    hotpepperApiFormImpl.lat = lat;
-    hotpepperApiFormImpl.lng = lng;
+    const generalConfigImpl: GeneralConfigImpl = new GeneralConfigImpl();
+    const generalConf: GeneralConfig = generalConfigImpl.getGeneralConf();
+
+    // parameter 作成
+    const priceRange = generalConf.priceRange?.sort();
+    hotpepperApiFormImpl.budgetMin = priceRange === undefined ? 0 : priceRange[0];
+    hotpepperApiFormImpl.budgetMax = priceRange === undefined ? hotpepperApiFormImpl.budgetMin : priceRange[1];
+    hotpepperApiFormImpl.lat = generalConf.latLng.lat;
+    hotpepperApiFormImpl.lng = generalConf.latLng.lng;
     return hotpepperApiFormImpl;
   }
 

--- a/src/lib/api/HotpepperApiForm.ts
+++ b/src/lib/api/HotpepperApiForm.ts
@@ -1,3 +1,5 @@
+import { BudgetList } from "../../lib/model/HotpepperBudgetModel";
+
 /**
  * Hot Pepper API検索用のパラメーター
  */
@@ -8,85 +10,6 @@ export type HotpepperApiForm = {
   count: number,
 };
 
-type Budget = {
-  code: string,
-  floor: number,
-  cap: number,
-}
-
-/**
- * 検索用ディナー予算マスタAPIを叩いて取得した情報
- * code: 検索用ディナー予算コード
- * floor: 下限金額（含む）
- * cap: 上限金額（含む）
- */
-const BudgetList: Array<Budget> = [
-  {
-    code: "B009",
-    floor: 0,
-    cap: 500,
-  },
-  {
-    code: "B010",
-    floor: 501,
-    cap: 1000,
-  },
-  {
-    code: "B011",
-    floor: 1001,
-    cap: 1500,
-  },
-  {
-    code: "B001",
-    floor: 1501,
-    cap: 2000,
-  },
-  {
-    code: "B002",
-    floor: 2001,
-    cap: 3000,
-  },
-  {
-    code: "B003",
-    floor: 3001,
-    cap: 4000,
-  },
-  {
-    code: "B008",
-    floor: 4001,
-    cap: 5000,
-  },
-  {
-    code: "B004",
-    floor: 5001,
-    cap: 7000,
-  },
-  {
-    code: "B005",
-    floor: 7001,
-    cap: 10000,
-  },
-  {
-    code: "B006",
-    floor: 10001,
-    cap: 15000,
-  },
-  {
-    code: "B012",
-    floor: 15001,
-    cap: 20000,
-  },
-  {
-    code: "B013",
-    floor: 20001,
-    cap: 30000,
-  },
-  {
-    code: "B014",
-    floor: 30001,
-    cap: Number.MAX_SAFE_INTEGER,
-  },
-]
 // ToDo:
 //       - 100個取得して、そこからランダムに4個選択する
 export class HotpepperApiFormImpl {

--- a/src/lib/api/HotpepperApiForm.ts
+++ b/src/lib/api/HotpepperApiForm.ts
@@ -14,31 +14,39 @@ export type HotpepperApiForm = {
 //       - 100個取得して、そこからランダムに4個選択する
 export class HotpepperApiFormImpl {
   private apiForm: Array<HotpepperApiForm>;
+  private budgetMin: number = 0;
+  private budgetMax: number = 0;
+  private lat: number = 0;
+  private lng: number = 0;
 
   constructor() {
     this.apiForm = [];
   }
 
-  public getApiForm() {
-    return this.apiForm;
-  }
-
   public static newFromConfig(budgetMin: number, budgetMax: number, lat: number, lng: number): HotpepperApiFormImpl {
     const hotpepperApiFormImpl: HotpepperApiFormImpl = new HotpepperApiFormImpl();
+    hotpepperApiFormImpl.budgetMin = budgetMin;
+    hotpepperApiFormImpl.budgetMax = budgetMax;
+    hotpepperApiFormImpl.lat = lat;
+    hotpepperApiFormImpl.lng = lng;
+    return hotpepperApiFormImpl;
+  }
+
+  public toApi(): Array<HotpepperApiForm> {
     const matchedBudget = BudgetList.filter(budget => {
-      return budgetMin <= budget.cap && budget.floor <= budgetMax;
+      return this.budgetMin <= budget.cap && budget.floor <= this.budgetMax;
     });
     console.log('matchedBudget:', matchedBudget);
     const countMax = 100;
     const count = Math.floor(countMax / matchedBudget.length);
-    hotpepperApiFormImpl.apiForm = matchedBudget.map(budget => {
+    this.apiForm = matchedBudget.map(budget => {
       return {
         budget: budget.code,
-        lat: lat,
-        lng: lng,
+        lat: this.lat,
+        lng: this.lng,
         count: count,
       }
     });
-    return hotpepperApiFormImpl;
+    return this.apiForm;
   }
 }

--- a/src/lib/api/HotpepperApiForm.ts
+++ b/src/lib/api/HotpepperApiForm.ts
@@ -10,8 +10,6 @@ export type HotpepperApiForm = {
   count: number,
 };
 
-// ToDo:
-//       - 100個取得して、そこからランダムに4個選択する
 export class HotpepperApiFormImpl {
   private apiForm: Array<HotpepperApiForm>;
   private budgetMin: number = 0;

--- a/src/lib/api/HotpepperApiForm.ts
+++ b/src/lib/api/HotpepperApiForm.ts
@@ -2,6 +2,109 @@
  * Hot Pepper API検索用のパラメーター
  */
 export type HotpepperApiForm = {
+  budget: string | null | undefined,
   lat: number | null | undefined,
   lng: number | null | undefined,
 };
+
+type Budget = {
+  code: string,
+  floor: number,
+  cap: number,
+}
+
+const BudgetList: Array<Budget> = [
+  {
+    code: "B009",
+    floor: 0,
+    cap: 500,
+  },
+  {
+    code: "B010",
+    floor: 501,
+    cap: 1000,
+  },
+  {
+    code: "B011",
+    floor: 1001,
+    cap: 1500,
+  },
+  {
+    code: "B001",
+    floor: 1501,
+    cap: 2000,
+  },
+  {
+    code: "B002",
+    floor: 2001,
+    cap: 3000,
+  },
+  {
+    code: "B003",
+    floor: 3001,
+    cap: 4000,
+  },
+  {
+    code: "B008",
+    floor: 4001,
+    cap: 5000,
+  },
+  {
+    code: "B004",
+    floor: 5001,
+    cap: 7000,
+  },
+  {
+    code: "B005",
+    floor: 7001,
+    cap: 10000,
+  },
+  {
+    code: "B006",
+    floor: 10001,
+    cap: 15000,
+  },
+  {
+    code: "B012",
+    floor: 15001,
+    cap: 20000,
+  },
+  {
+    code: "B013",
+    floor: 20001,
+    cap: 30000,
+  },
+  {
+    code: "B014",
+    floor: 30001,
+    cap: Number.MAX_SAFE_INTEGER,
+  },
+]
+// ToDo:
+//       - 100個取得して、そこからランダムに4個選択する
+export class HotpepperApiFormImpl {
+  private apiForm: Array<HotpepperApiForm>;
+
+  constructor() {
+    this.apiForm = [];
+  }
+
+  public getApiForm() {
+    return this.apiForm;
+  }
+
+  public static newFromConfig(budgetMin: number, budgetMax: number, lat: number, lng: number): HotpepperApiFormImpl {
+    const hotpepperApiFormImpl: HotpepperApiFormImpl = new HotpepperApiFormImpl();
+    const matchedBudget = BudgetList.filter(budget => {
+      return budgetMin <= budget.cap && budget.floor <= budgetMax;
+    });
+    hotpepperApiFormImpl.apiForm = matchedBudget.map(budget => {
+      return {
+        budget: budget.code,
+        lat: lat,
+        lng: lng,
+      }
+    });
+    return hotpepperApiFormImpl;
+  }
+}

--- a/src/lib/api/HotpepperApiForm.ts
+++ b/src/lib/api/HotpepperApiForm.ts
@@ -5,6 +5,7 @@ export type HotpepperApiForm = {
   budget: string | null | undefined,
   lat: number | null | undefined,
   lng: number | null | undefined,
+  count: number,
 };
 
 type Budget = {
@@ -104,11 +105,15 @@ export class HotpepperApiFormImpl {
     const matchedBudget = BudgetList.filter(budget => {
       return budgetMin <= budget.cap && budget.floor <= budgetMax;
     });
+    console.log('matchedBudget:', matchedBudget);
+    const countMax = 100;
+    const count = Math.floor(countMax / matchedBudget.length);
     hotpepperApiFormImpl.apiForm = matchedBudget.map(budget => {
       return {
         budget: budget.code,
         lat: lat,
         lng: lng,
+        count: count,
       }
     });
     return hotpepperApiFormImpl;

--- a/src/lib/api/HotpepperApiForm.ts
+++ b/src/lib/api/HotpepperApiForm.ts
@@ -13,6 +13,12 @@ type Budget = {
   cap: number,
 }
 
+/**
+ * 検索用ディナー予算マスタAPIを叩いて取得した情報
+ * code: 検索用ディナー予算コード
+ * floor: 下限金額（含む）
+ * cap: 上限金額（含む）
+ *  */
 const BudgetList: Array<Budget> = [
   {
     code: "B009",

--- a/src/lib/api/HotpepperApiForm.ts
+++ b/src/lib/api/HotpepperApiForm.ts
@@ -19,7 +19,7 @@ type Budget = {
  * code: 検索用ディナー予算コード
  * floor: 下限金額（含む）
  * cap: 上限金額（含む）
- *  */
+ */
 const BudgetList: Array<Budget> = [
   {
     code: "B009",

--- a/src/lib/model/GeneralConfigModel.ts
+++ b/src/lib/model/GeneralConfigModel.ts
@@ -8,7 +8,7 @@ export type GeneralConfig = {
     lat: number | null | undefined;
     lng: number | null | undefined;
   }
-  priceRange: string | null | undefined;
+  priceRange: number[] | null | undefined;
   searchStoreRange: number | null | undefined;
 };
 

--- a/src/lib/model/HotpepperBudgetModel.ts
+++ b/src/lib/model/HotpepperBudgetModel.ts
@@ -1,0 +1,79 @@
+type Budget = {
+  code: string,
+  floor: number,
+  cap: number,
+}
+
+/**
+ * 検索用ディナー予算マスタAPIを叩いて取得した情報
+ * code: 検索用ディナー予算コード
+ * floor: 下限金額（含む）
+ * cap: 上限金額（含む）
+ */
+export const BudgetList: Array<Budget> = [
+  {
+    code: "B009",
+    floor: 0,
+    cap: 500,
+  },
+  {
+    code: "B010",
+    floor: 501,
+    cap: 1000,
+  },
+  {
+    code: "B011",
+    floor: 1001,
+    cap: 1500,
+  },
+  {
+    code: "B001",
+    floor: 1501,
+    cap: 2000,
+  },
+  {
+    code: "B002",
+    floor: 2001,
+    cap: 3000,
+  },
+  {
+    code: "B003",
+    floor: 3001,
+    cap: 4000,
+  },
+  {
+    code: "B008",
+    floor: 4001,
+    cap: 5000,
+  },
+  {
+    code: "B004",
+    floor: 5001,
+    cap: 7000,
+  },
+  {
+    code: "B005",
+    floor: 7001,
+    cap: 10000,
+  },
+  {
+    code: "B006",
+    floor: 10001,
+    cap: 15000,
+  },
+  {
+    code: "B012",
+    floor: 15001,
+    cap: 20000,
+  },
+  {
+    code: "B013",
+    floor: 20001,
+    cap: 30000,
+  },
+  {
+    code: "B014",
+    floor: 30001,
+    cap: Number.MAX_SAFE_INTEGER,
+  },
+]

--- a/src/lib/model/HotpepperShopResponseList.ts
+++ b/src/lib/model/HotpepperShopResponseList.ts
@@ -1,0 +1,30 @@
+export class HotpepperShopResponseListImpl {
+  private responseData: any;
+
+  public static async newFromResponse(responseData: any){
+    const hotpepperShopResponseListImpl:HotpepperShopResponseListImpl = new HotpepperShopResponseListImpl();
+    hotpepperShopResponseListImpl.responseData = responseData;
+    return hotpepperShopResponseListImpl;
+  }
+
+  public async selectShops(): Promise<Object | null>{
+    try {
+      // TODO: Hotpepper APIを採用していく場合は型を用意してレスポンスを解析する
+      let selectedShops = this.responseData.then((responses: Iterable<any> | ArrayLike<any>) => {
+        let nestedResponses: Array<any> = Array.from(responses);
+        let flattenedResponses = [].concat.apply([],nestedResponses);
+        console.log('Num of all response data:', flattenedResponses.length);
+        const selectedNum = 4;
+        const selectedResponses = [...Array(selectedNum)].map(() =>
+          flattenedResponses.splice(Math.floor(Math.random() * flattenedResponses.length), 1)[0]);
+        console.log('Num of selected data:', selectedResponses.length);
+        return selectedResponses;
+      });
+      return selectedShops;
+    } catch (error) {
+      console.log(error);
+      return null;
+    }
+  }
+
+}


### PR DESCRIPTION
### 先行PR
なし

### 内容
- JIRA: [AP-29](https://naruhiyo.atlassian.net/browse/AP-29)

### 動作確認項目
- 高々100件の取得データから4件を抽出していること
- settings.jsonで設定した`priceRange`を含む、最小範囲の予算コードで検索できていること

### 動作確認結果
- settings.jsonに設定した`priceRange`に基づいて検索結果が返却されている
  - settings.jsonのpriceRange: 2200~3300
  - 検索結果の1件目のbudget.name: 3001~4000
- 高々100件の取得データから4件を抽出していること
  - `Num of all response data`, `Num of selected data`箇所

![image](https://user-images.githubusercontent.com/28133383/118565753-b3e0a000-b7ad-11eb-8ba9-aeb5eac16c6f.png)

#### settings.json
![image](https://user-images.githubusercontent.com/28133383/118565814-d07cd800-b7ad-11eb-84b4-465ebcffe90a.png)




### 備考
なし